### PR TITLE
bump action from Node12 to Node16

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -19,7 +19,7 @@ outputs:
   response-text:
     description: The Arweave HTTP API response status text.
 runs:
-  using: node12
+  using: node16
   main: index.js
 branding:
   icon: clock


### PR DESCRIPTION
The GitHub Actions workflow gives the following annotation while running the action:

> Node.js 12 actions are deprecated. For more information see: github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12.

Signed-off-by: Enes <ahmedenesturan@gmail.com>